### PR TITLE
fixed handling of thread handles for aresWorker to prevent crashes on…

### DIFF
--- a/syslibs/comm/TCPbind/model/TCPbind.ovm
+++ b/syslibs/comm/TCPbind/model/TCPbind.ovm
@@ -47,6 +47,8 @@ LIBRARY TCPbind
 		VARIABLES
 			threadHandle	:	C_TYPE	<TCPB_THREADHANDLE>
 				COMMENT	=	"Handle to getAddrInfoThread";
+			handleValid		:	BOOL
+				COMMENT	=	"TRUE states that the handle is created and usable";
 		END_VARIABLES;
 		OPERATIONS
 			constructor	:	C_FUNCTION	<OV_FNC_CONSTRUCTOR>;

--- a/syslibs/comm/TCPbind/source/TCPbind_open.c
+++ b/syslibs/comm/TCPbind/source/TCPbind_open.c
@@ -179,7 +179,6 @@ OV_RESULT ov_library_setglobalvars_TCPbind_new(void) {
 	pNewAresWorker = Ov_StaticPtrCast(TCPbind_aresWorker, Ov_SearchChild(ov_containment, pTCPbindDom, "aresWorker"));
 	if(pNewAresWorker)
 		Ov_DeleteObject(pNewAresWorker);
-
 	result = Ov_CreateObject(TCPbind_aresWorker, pNewAresWorker, pTCPbindDom, "aresWorker");
 	if(Ov_Fail(result))
 	{

--- a/syslibs/comm/TCPbind/source/aresWorker.c
+++ b/syslibs/comm/TCPbind/source/aresWorker.c
@@ -301,10 +301,10 @@ OV_DLLFNCEXPORT void TCPbind_aresWorker_shutdown(
 	OV_INSTPTR_TCPbind_aresWorker pinst = Ov_StaticPtrCast(TCPbind_aresWorker, pobj);
 	struct getAddrInfoElem *pCurrElem, *pNextElem;
 	/* do what */
-#if OV_SYSTEM_NT
-	/*	yes, here it waits until the thread is through....	*/
-	InterlockedExchange(&(runWorkerThread), 0);
 	if(pinst->v_handleValid){
+#if OV_SYSTEM_NT
+		/*	yes, here it waits until the thread is through....	*/
+		InterlockedExchange(&(runWorkerThread), 0);
 		if(WaitForSingleObject(pinst->v_threadHandle, 5000) != WAIT_OBJECT_0){
 			KS_logfile_warning(("%s: worker thread did not terminate correctly and in time. some memory might be lost."));
 		}


### PR DESCRIPTION
… database restart

inserted a threadValid variable to check if the thread is running on Windows and Linux as these handles are used differently there.