### PR TITLE
proper support for iteration over array elements

### DIFF
--- a/addonlibs/hmi/hmiJavaScript/JavaScript/hmi-class-cshmi.js
+++ b/addonlibs/hmi/hmiJavaScript/JavaScript/hmi-class-cshmi.js
@@ -3191,9 +3191,7 @@ cshmi.prototype = {
 				*/
 				
 				//get a rid of external brackets 
-				var response = req.responseText.replace(/{/g, "");
-				response = response.replace(/}/g, "");
-				var responseArray = HMI.KSClient.splitKsResponse(response, 1);
+				var responseArray = HMI.KSClient.splitKsResponse(req.responseText.slice(1, req.responseText.length-1), 0);
 				for (var i=0; i<responseArray.length; i++){
 					var responseDictionary = Array();
 					responseDictionary["OP_VALUE"] = responseArray[i];


### PR DESCRIPTION
Before this change iteration over vector variables killed all brackets and splitted on the remaining space.

Afterwards the vector entries are allowed to contain spaces. 
Tested on computer of @LarsNt 