### PR TITLE
fix tasklist structure

### DIFF
--- a/syslibs/fb/include/fb_database.h
+++ b/syslibs/fb/include/fb_database.h
@@ -4,7 +4,7 @@
 ***   #####################################                                 ***
 ***                                                                         ***
 ***   L T S o f t                                                           ***
-***   Agentur für Leittechnik Software GmbH                                 ***
+***   Agentur fÃ¼r Leittechnik Software GmbH                                 ***
 ***   Brabanterstr. 13                                                      ***
 ***   D-50171 Kerpen                                                        ***
 ***   Tel : 02237/92869-2                                                   ***
@@ -97,6 +97,7 @@ OV_DLLFNCEXPORT void* fb_database_geturtask(void);
 /*
  * check if task is connected to UrTask
  */
+#define FB_SEARCH_URTASK_MAX 64
 OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
 	OV_INSTPTR_fb_task ptask
 );

--- a/syslibs/fb/include/fb_database.h
+++ b/syslibs/fb/include/fb_database.h
@@ -95,10 +95,10 @@ OV_DLLFNCEXPORT OV_RESULT fb_database_checkstruct(void);
 OV_DLLFNCEXPORT void* fb_database_geturtask(void);
 
 /*
- * check if task is connected to UrTask
+ * check if task is connected to UrTask or an initial task
  */
-#define FB_SEARCH_URTASK_MAX 64
-OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
+#define FB_SEARCH_INITIAL_TASK_MAX 64
+OV_DLLFNCEXPORT OV_BOOL fb_task_has_initial_taskparent(
 	OV_INSTPTR_fb_task ptask
 );
 

--- a/syslibs/fb/include/fb_database.h
+++ b/syslibs/fb/include/fb_database.h
@@ -95,6 +95,13 @@ OV_DLLFNCEXPORT OV_RESULT fb_database_checkstruct(void);
 OV_DLLFNCEXPORT void* fb_database_geturtask(void);
 
 /*
+ * check if task is connected to UrTask
+ */
+OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
+	OV_INSTPTR_fb_task ptask
+);
+
+/*
 *	Get libraries container object
 */
 OV_DLLFNCEXPORT void* fb_database_getlibcontainer(void);

--- a/syslibs/fb/include/fb_database.h
+++ b/syslibs/fb/include/fb_database.h
@@ -97,7 +97,6 @@ OV_DLLFNCEXPORT void* fb_database_geturtask(void);
 /*
  * check if task is connected to UrTask or an initial task
  */
-#define FB_SEARCH_INITIAL_TASK_MAX 64
 OV_DLLFNCEXPORT OV_BOOL fb_task_has_initial_taskparent(
 	OV_INSTPTR_fb_task ptask
 );

--- a/syslibs/fb/model/fb.ovm
+++ b/syslibs/fb/model/fb.ovm
@@ -176,9 +176,11 @@ LIBRARY fb
             intask : CLASS fb/task;
         END_PARTS;
         OPERATIONS
-    		typemethod : C_FUNCTION <FB_FNC_TYPEMETHOD>;
-    		getport    : C_FUNCTION <FB_FNC_GETPORT>;
-			setport    : C_FUNCTION <FB_FNC_SETPORT>;
+			constructor : C_FUNCTION <OV_FNC_CONSTRUCTOR>;
+			execute     : C_FUNCTION <FB_FNC_EXECUTE>;
+    		typemethod  : C_FUNCTION <FB_FNC_TYPEMETHOD>;
+    		getport     : C_FUNCTION <FB_FNC_GETPORT>;
+			setport     : C_FUNCTION <FB_FNC_SETPORT>;
         END_OPERATIONS;
     END_CLASS;
     
@@ -336,8 +338,9 @@ LIBRARY fb
         END_VARIABLES;
     END_CLASS;
     
-    	CLASS controlchart : CLASS fb/functionchart
+    CLASS controlchart : CLASS fb/functionchart
 		IS_INSTANTIABLE;
+		FLAGS = "i";
 		COMMENT = "a Chart with ability to provide services";
 		VARIABLES
 			CMD			: STRING	HAS_SET_ACCESSOR 	FLAGS = "i" COMMENT = "Command input for services";

--- a/syslibs/fb/source/ControlChart.c
+++ b/syslibs/fb/source/ControlChart.c
@@ -280,7 +280,7 @@ OV_DLLFNCEXPORT void fb_controlchart_typemethod(
 		}
 	}*/
 
-	/* Trigger all connections and internal tasks */
+	/* make sure intask is linked correctly */
 	fb_functionchart_typemethod(pfb, pltc);
 
 	return;

--- a/syslibs/fb/source/fb_database.c
+++ b/syslibs/fb/source/fb_database.c
@@ -260,9 +260,9 @@ OV_DLLFNCEXPORT void* fb_database_geturtask(void) {
 }
 
 /*
- * check if task is connected to UrTask
+ * check if task is connected to UrTask or an initial task
  */
-OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
+OV_DLLFNCEXPORT OV_BOOL fb_task_has_initial_taskparent(
 	OV_INSTPTR_fb_task ptask){
 	OV_INSTPTR_fb_task urtask = (OV_INSTPTR_fb_task)fb_database_geturtask();
 	OV_INSTPTR_fb_task pcurTask = Ov_GetParent(fb_tasklist, ptask);
@@ -272,14 +272,14 @@ OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
 	for(pcurTask=ptask; pcurTask; pcurTask=Ov_GetParent(fb_tasklist, pcurTask)){
 		if(pcurTask==urtask)
 			return TRUE;
-		if(count > FB_SEARCH_URTASK_MAX){
+		if(count > FB_SEARCH_INITIAL_TASK_MAX){
 			ov_logfile_warning("%s: max search depth reached; assuming not connected to urtask", ptask->v_identifier);
 			return FALSE;
 		}
 		count++;
 	}
 
-	return FALSE;
+	return TRUE;
 }
 
 /*	----------------------------------------------------------------------	*/

--- a/syslibs/fb/source/fb_database.c
+++ b/syslibs/fb/source/fb_database.c
@@ -259,6 +259,22 @@ OV_DLLFNCEXPORT void* fb_database_geturtask(void) {
 	return (void*)pUrTask;
 }
 
+/*
+ * check if task is connected to UrTask
+ */
+OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
+	OV_INSTPTR_fb_task ptask){
+	OV_INSTPTR_fb_task urtask = (OV_INSTPTR_fb_task)fb_database_geturtask();
+	OV_INSTPTR_fb_task pcurTask = Ov_GetParent(fb_tasklist, ptask);
+
+	for(pcurTask=ptask; pcurTask; pcurTask=Ov_GetParent(fb_tasklist, pcurTask)){
+		if(pcurTask==urtask)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
 /*	----------------------------------------------------------------------	*/
 
 /*

--- a/syslibs/fb/source/fb_database.c
+++ b/syslibs/fb/source/fb_database.c
@@ -267,12 +267,13 @@ OV_DLLFNCEXPORT OV_BOOL fb_task_has_initial_taskparent(
 	OV_INSTPTR_fb_task urtask = (OV_INSTPTR_fb_task)fb_database_geturtask();
 	OV_INSTPTR_fb_task pcurTask = Ov_GetParent(fb_tasklist, ptask);
 
-	int count = 0;
+	OV_UINT count = 0;
+	OV_UINT max_count = ov_vendortree_MaxHierarchyDepth() * 2;
 
 	for(pcurTask=ptask; pcurTask; pcurTask=Ov_GetParent(fb_tasklist, pcurTask)){
 		if(pcurTask==urtask)
 			return TRUE;
-		if(count > FB_SEARCH_INITIAL_TASK_MAX){
+		if(count > max_count){
 			ov_logfile_warning("%s: max search depth reached; assuming not connected to urtask", ptask->v_identifier);
 			return FALSE;
 		}

--- a/syslibs/fb/source/fb_database.c
+++ b/syslibs/fb/source/fb_database.c
@@ -4,7 +4,7 @@
 ***   #####################################                                 ***
 ***                                                                         ***
 ***   L T S o f t                                                           ***
-***   Agentur f�r Leittechnik Software GmbH                                 ***
+***   Agentur für Leittechnik Software GmbH                                 ***
 ***   Brabanterstr. 13                                                      ***
 ***   D-50171 Kerpen                                                        ***
 ***   Tel : 02237/92869-2                                                   ***
@@ -267,9 +267,16 @@ OV_DLLFNCEXPORT OV_BOOL fb_task_is_urtaskchild(
 	OV_INSTPTR_fb_task urtask = (OV_INSTPTR_fb_task)fb_database_geturtask();
 	OV_INSTPTR_fb_task pcurTask = Ov_GetParent(fb_tasklist, ptask);
 
+	int count = 0;
+
 	for(pcurTask=ptask; pcurTask; pcurTask=Ov_GetParent(fb_tasklist, pcurTask)){
 		if(pcurTask==urtask)
 			return TRUE;
+		if(count > FB_SEARCH_URTASK_MAX){
+			ov_logfile_warning("%s: max search depth reached; assuming not connected to urtask", ptask->v_identifier);
+			return FALSE;
+		}
+		count++;
 	}
 
 	return FALSE;

--- a/syslibs/fb/source/fb_setvar.c
+++ b/syslibs/fb/source/fb_setvar.c
@@ -2389,6 +2389,10 @@ fprintf(stderr, "ANY: INT_VAL %" OV_PRINT_INT " != %" OV_PRINT_INT "\n",pany->va
 	           return OV_ERR_BADTYPE;
     }
 
+    if(pelem->elemunion.pvar->v_setfnc){
+    	return ov_object_setvar(pobj, pelem, pvarcurrprops);;
+    }
+
     return OV_ERR_OK;
 }
 

--- a/syslibs/ssc/model/ssc.ovm
+++ b/syslibs/ssc/model/ssc.ovm
@@ -56,6 +56,7 @@ LIBRARY ssc
 
 	CLASS SequentialStateChart : CLASS fb/functionchart
 		IS_INSTANTIABLE;
+		FLAGS = "i";
 		COMMENT = "holds all steps and transitions and does the call logic";
 		VARIABLES
 			EN   			: UINT   						FLAGS = "i"	COMMENT = "enable execution: stop=0/start=1/break=2/reset=3" INITIALVALUE = 0;

--- a/syslibs/ssc/source/SequentialStateChart.c
+++ b/syslibs/ssc/source/SequentialStateChart.c
@@ -133,9 +133,17 @@ OV_DLLFNCEXPORT OV_RESULT ssc_SequentialStateChart_constructor(
 	result = Ov_CreateObject(ssc_step, pEndStep, pinst, "END");
 	pEndStep->v_internalRole = SSC_STEPROLE_END;
 
+	// link ssc tasks to intask
+	result = Ov_Link(fb_tasklist, &pinst->p_intask, &pinst->p_taskActiveStep);
+	if(Ov_Fail(result))
+		return result;
+	result = Ov_Link(fb_tasklist, &pinst->p_intask, &pinst->p_trans);
+	if(Ov_Fail(result))
+		return result;
+
 	//init variables
 	pinst->v_workingState = SSC_WOST_INIT;
-	pinst->v_actimode = FB_AM_ON;
+	//pinst->v_actimode = FB_AM_ON;
 	//pinst->v_iexreq = TRUE;
 
 	return OV_ERR_OK;
@@ -425,10 +433,6 @@ OV_DLLFNCEXPORT void ssc_SequentialStateChart_typemethod(
     } while (!exitLoop);
     /* END: state machine: working state
     #################################*/
-
-	/* Execute internal tasks */
-	Ov_Call1 (fb_task, taskActivestep, execute, pltc);
-	Ov_Call1 (fb_task, pTrans, execute, pltc);
 
 	/* Trigger all connections on chart output ports */
 	//fb_object_triggerOutSendConnections(Ov_PtrUpCast(fb_object, pinst));

--- a/syslibs/ssc/source/SequentialStateChart.c
+++ b/syslibs/ssc/source/SequentialStateChart.c
@@ -122,7 +122,7 @@ OV_DLLFNCEXPORT OV_RESULT ssc_SequentialStateChart_constructor(
 	OV_RESULT    result;
 
 	/* do what the base class does first */
-	result = fb_functionblock_constructor(pobj);
+	result = fb_functionchart_constructor(pobj);
 	if(Ov_Fail(result))
 		return result;
 
@@ -136,7 +136,7 @@ OV_DLLFNCEXPORT OV_RESULT ssc_SequentialStateChart_constructor(
 	//init variables
 	pinst->v_workingState = SSC_WOST_INIT;
 	pinst->v_actimode = FB_AM_ON;
-	pinst->v_iexreq = TRUE;
+	//pinst->v_iexreq = TRUE;
 
 	return OV_ERR_OK;
 }
@@ -156,14 +156,8 @@ OV_DLLFNCEXPORT void ssc_SequentialStateChart_typemethod(
     OV_RESULT    			 result;
     OV_BOOL	                 exitLoop = TRUE;
 
-	OV_INSTPTR_fb_task          intask = Ov_GetPartPtr(intask, pinst);
-
-	/* Init functionchart intask */
-	intask->v_actimode = FB_AM_ON;
-	intask->v_cyctime.secs = 0;
-	intask->v_cyctime.usecs = 0;
-	intask->v_proctime = *pltc;
-
+    /* make sure intask is linked correctly */
+    fb_functionchart_typemethod(pfb, pltc);
 
     // init variables
     pinst->v_error=FALSE;
@@ -173,8 +167,9 @@ OV_DLLFNCEXPORT void ssc_SequentialStateChart_typemethod(
     taskActivestep->v_cyctime.usecs = 0;
     pTrans->v_actimode = FB_AM_ON;
 
+
 	/* Trigger all connections on chart input ports */
-	fb_object_triggerInpGetConnections(Ov_PtrUpCast(fb_object, pinst));
+	//fb_object_triggerInpGetConnections(Ov_PtrUpCast(fb_object, pinst));
 
     // find active step
     Ov_GetFirstChildEx(fb_tasklist, taskActivestep, pActiveStep, ssc_step);
@@ -435,11 +430,8 @@ OV_DLLFNCEXPORT void ssc_SequentialStateChart_typemethod(
 	Ov_Call1 (fb_task, taskActivestep, execute, pltc);
 	Ov_Call1 (fb_task, pTrans, execute, pltc);
 
-	/* Execute internal SSC task */
-	Ov_Call1(fb_task, intask, execute, pltc);
-
 	/* Trigger all connections on chart output ports */
-	fb_object_triggerOutSendConnections(Ov_PtrUpCast(fb_object, pinst));
+	//fb_object_triggerOutSendConnections(Ov_PtrUpCast(fb_object, pinst));
 
 	return;
 }

--- a/syslibs/ssc/source/SequentialStateChart.c
+++ b/syslibs/ssc/source/SequentialStateChart.c
@@ -143,8 +143,6 @@ OV_DLLFNCEXPORT OV_RESULT ssc_SequentialStateChart_constructor(
 
 	//init variables
 	pinst->v_workingState = SSC_WOST_INIT;
-	//pinst->v_actimode = FB_AM_ON;
-	//pinst->v_iexreq = TRUE;
 
 	return OV_ERR_OK;
 }
@@ -174,10 +172,6 @@ OV_DLLFNCEXPORT void ssc_SequentialStateChart_typemethod(
     taskActivestep->v_cyctime.secs = 0;
     taskActivestep->v_cyctime.usecs = 0;
     pTrans->v_actimode = FB_AM_ON;
-
-
-	/* Trigger all connections on chart input ports */
-	//fb_object_triggerInpGetConnections(Ov_PtrUpCast(fb_object, pinst));
 
     // find active step
     Ov_GetFirstChildEx(fb_tasklist, taskActivestep, pActiveStep, ssc_step);
@@ -434,9 +428,6 @@ OV_DLLFNCEXPORT void ssc_SequentialStateChart_typemethod(
     /* END: state machine: working state
     #################################*/
 
-	/* Trigger all connections on chart output ports */
-	//fb_object_triggerOutSendConnections(Ov_PtrUpCast(fb_object, pinst));
-
 	return;
 }
 
@@ -450,8 +441,6 @@ OV_DLLFNCEXPORT OV_RESULT ssc_SequentialStateChart_resetSsc(
 	OV_INSTPTR_fb_functionblock pFbAction=NULL;
 	OV_INSTPTR_ssc_SequentialStateChart pSscAction = NULL;
 	OV_RESULT result = OV_ERR_OK;
-	//OV_ANY orderVar = OV_ANY_INIT;
-	//OV_UINT iterator = 0;
 
 	//reset all steps; find and link INIT-step to taskActiveStep
 	Ov_ForEachChildEx(ov_containment, pinst, pStep, ssc_step){

--- a/syslibs/ssc/source/actionBlock_execute.c
+++ b/syslibs/ssc/source/actionBlock_execute.c
@@ -22,6 +22,7 @@
 #endif
 
 #include "ssclib.h"
+#include "fb_database.h"
 
 /**
  * gets an object pointer from a execute object
@@ -120,7 +121,10 @@ OV_DLLFNCEXPORT void ssc_execute_typemethod(
 		pTargetSequentialControlChart->v_EN = SSC_CMD_START;
 	}
 	// execute action for once
-	Ov_Call1 (fb_task, Ov_PtrUpCast(fb_task, pTargetObj), execute, pltc);
+	if(fb_task_is_urtaskchild(Ov_PtrUpCast(fb_task, pTargetObj)))
+		Ov_Call1 (fb_task, Ov_PtrUpCast(fb_task, pTargetObj), execute, pltc);
+	else
+		ov_logfile_warning("%s: tried to execute fb %s which is not connected to UrTask", pinst->v_identifier, pTargetObj->v_identifier);
 
 	//restore config of targetObject
 	pTargetObj->v_actimode = targetActimode;

--- a/syslibs/ssc/source/actionBlock_execute.c
+++ b/syslibs/ssc/source/actionBlock_execute.c
@@ -121,7 +121,7 @@ OV_DLLFNCEXPORT void ssc_execute_typemethod(
 		pTargetSequentialControlChart->v_EN = SSC_CMD_START;
 	}
 	// execute action for once
-	if(fb_task_is_urtaskchild(Ov_PtrUpCast(fb_task, pTargetObj)))
+	if(fb_task_has_initial_taskparent(Ov_PtrUpCast(fb_task, pTargetObj)))
 		Ov_Call1 (fb_task, Ov_PtrUpCast(fb_task, pTargetObj), execute, pltc);
 	else
 		ov_logfile_warning("%s: tried to execute fb %s which is not connected to UrTask", pinst->v_identifier, pTargetObj->v_identifier);

--- a/syslibs/ssc/source/actionBlock_execute.c
+++ b/syslibs/ssc/source/actionBlock_execute.c
@@ -121,10 +121,14 @@ OV_DLLFNCEXPORT void ssc_execute_typemethod(
 		pTargetSequentialControlChart->v_EN = SSC_CMD_START;
 	}
 	// execute action for once
+#if OV_DEBUG
 	if(fb_task_has_initial_taskparent(Ov_PtrUpCast(fb_task, pTargetObj)))
 		Ov_Call1 (fb_task, Ov_PtrUpCast(fb_task, pTargetObj), execute, pltc);
 	else
 		ov_logfile_warning("%s: tried to execute fb %s which is not connected to UrTask", pinst->v_identifier, pTargetObj->v_identifier);
+#else
+	Ov_Call1 (fb_task, Ov_PtrUpCast(fb_task, pTargetObj), execute, pltc);
+#endif
 
 	//restore config of targetObject
 	pTargetObj->v_actimode = targetActimode;

--- a/syslibs/ssc/source/step.c
+++ b/syslibs/ssc/source/step.c
@@ -193,7 +193,7 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
 						// stop subSSC
 						pSubSsc = Ov_StaticPtrCast(ssc_SequentialStateChart, pTargetObj);
     					pSubSsc->v_EN = SSC_CMD_STOP;
-    					if(fb_task_is_urtaskchild(Ov_PtrUpCast(fb_task, pSubSsc)))
+    					if(fb_task_has_initial_taskparent(Ov_PtrUpCast(fb_task, pSubSsc)))
     						Ov_Call1(fb_task, Ov_PtrUpCast(fb_task, pSubSsc), execute, pltc);
     					else
     						ov_logfile_warning("%s: tried to execute ssc %s which is not connected to UrTask", pinst->v_identifier, pSubSsc->v_identifier);

--- a/syslibs/ssc/source/step.c
+++ b/syslibs/ssc/source/step.c
@@ -210,8 +210,12 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
 				}
 
     			/* exit */
-				if(pExit->v_actimode!=FB_AM_ON || fb_task_is_urtaskchild(pExit))
-					Ov_Call1 (fb_task, pExit, execute, pltc);
+				// check exit task is linked correctly
+				if(Ov_GetParent(fb_tasklist, pExit)!=(Ov_PtrUpCast(fb_task,pinst))){
+					Ov_Unlink(fb_tasklist, Ov_GetParent(fb_tasklist, pExit), pExit);
+					Ov_Link(fb_tasklist, pinst, pExit);
+				}
+				Ov_Call1 (fb_task, pExit, execute, pltc);
     			pDo->v_actimode = FB_AM_OFF;
     			// unlink from SequentialStateChart.taskActiveStep
     			Ov_Unlink(fb_tasklist, Ov_GetParent(fb_tasklist, pinst), pinst);

--- a/syslibs/ssc/source/step.c
+++ b/syslibs/ssc/source/step.c
@@ -149,7 +149,7 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
         				pNextStep = Ov_GetParent(ssc_previousTransitions, pTransition);
         				if(pNextStep){
         					//transition is correct linked
-        					if(!Ov_GetParent(fb_tasklist, pNextStep)){
+        					if(Ov_GetParent(fb_tasklist, pNextStep)){
         						//ensure the next step is linked right
         						Ov_Unlink(fb_tasklist, Ov_GetParent(fb_tasklist, pNextStep), pNextStep);
         					}
@@ -187,7 +187,7 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
 					}
 				}
 
-				if (pSSC->v_workingState == SSC_WOST_STOP){
+				if (pinst->v_evTransTrigger){
 					//we are leaving the step
 					pExit->v_actimode = FB_AM_ONCE;
 				}

--- a/syslibs/ssc/source/step.c
+++ b/syslibs/ssc/source/step.c
@@ -57,9 +57,9 @@ OV_DLLFNCEXPORT OV_RESULT ssc_step_constructor(
 	// local tasklist
 	pEntry->v_actimode = FB_AM_ON;
 	pDo->v_actimode = FB_AM_ON;
-	pExit->v_actimode = FB_AM_ON;
+	pExit->v_actimode = FB_AM_OFF;
 
-	// link do task
+	// link entry, do and exit task
 	result = Ov_Link(fb_tasklist, pinst, pEntry);
 	if(Ov_Fail(result))
 		return result;
@@ -132,14 +132,10 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
     			//initialized with zero
     			ov_time_diff(&pinst->v_T, &pinst->v_startTime, &pinst->v_startTime);
     			//printf("%s/%s/entry\n", pSSC->v_identifier, pinst->v_identifier);
-    			//Ov_Call1 (fb_task, pEntry, execute, pltc);
     			pinst->v_qualifier = SSC_QUALIFIER_DO;
     			pEntry->v_actimode = FB_AM_ONCE;
     			pDo->v_actimode = FB_AM_ON;
     		}
-    		/* do */
-    		//printf("%s/%s/do\n", pSSC->v_identifier, pinst->v_identifier);
-    		//Ov_Call1 (fb_task, pDo, execute, pltc);
 
     		/* event: SSC terminates */
     		if (pinst->v_internalRole == SSC_STEPROLE_END){

--- a/syslibs/ssc/source/step.c
+++ b/syslibs/ssc/source/step.c
@@ -193,10 +193,14 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
 						// stop subSSC
 						pSubSsc = Ov_StaticPtrCast(ssc_SequentialStateChart, pTargetObj);
     					pSubSsc->v_EN = SSC_CMD_STOP;
+#if OV_DEBUG
     					if(fb_task_has_initial_taskparent(Ov_PtrUpCast(fb_task, pSubSsc)))
     						Ov_Call1(fb_task, Ov_PtrUpCast(fb_task, pSubSsc), execute, pltc);
     					else
     						ov_logfile_warning("%s: tried to execute ssc %s which is not connected to UrTask", pinst->v_identifier, pSubSsc->v_identifier);
+#else
+						Ov_Call1(fb_task, Ov_PtrUpCast(fb_task, pSubSsc), execute, pltc);
+#endif
 					}
 				}
 

--- a/syslibs/ssc/source/step.c
+++ b/syslibs/ssc/source/step.c
@@ -204,10 +204,8 @@ OV_DLLFNCEXPORT void ssc_step_typemethod(
 					}
 				}
 
-				if (pinst->v_evTransTrigger){
-					//we are leaving the step
-					pExit->v_actimode = FB_AM_ONCE;
-				}
+				//we are leaving the step
+				pExit->v_actimode = FB_AM_ONCE;
 
     			/* exit */
 				// check exit task is linked correctly


### PR DESCRIPTION
This pull request fixes #59 .

Change Summary:
- `intask`s are now link to parent chart
- step and transition tasks of SSCs are automatically linked into `intask`
- execution order of function blocks, steps, and transitions can now be changed by reordering `intask` task list
- debug builds try to find an initial task before executing function blocks from C, providing warnings if unsuccessful

Breaking changes:
- timing of vdivde3696 function blocks may change for saved databases
  - affected types: `fio`, `aver`, `c`, `cs`, `deadt`, `dif`, `hn`, `integr`, `seo`, `tof1`, `ton1`, `tp1`
- loading saves on an old system causes doubled executions of function blocks