### PR TITLE
add feature to change object positions in an association without unlinking

### DIFF
--- a/core/ov/source/ov_association.c
+++ b/core/ov/source/ov_association.c
@@ -558,16 +558,16 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 					pcurrparent = pparent;
 					break;
 				case OV_PMH_BEGIN:
-					pcurrparent = pit->child.pprevious?NULL:pparent;
+					pcurrparent = pit->child.pprevious?(NULL):pparent;
 					break;
 				case OV_PMH_END:
 					pcurrparent = pit->child.pnext?(NULL):pparent;
 					break;
 				case OV_PMH_BEFORE:
-					pcurrparent = (pit->child.pnext)->parent.pparent==prelparent?(pparent):(NULL);
+					pcurrparent = (pit->child.pnext)?(pit->child.pnext)->parent.pparent==prelparent?(pparent):(NULL):(NULL);
 					break;
 				case OV_PMH_AFTER:
-					pcurrparent = (pit->child.pprevious)->parent.pparent==prelparent?(pparent):(NULL);
+					pcurrparent = (pit->child.pprevious)?(pit->child.pprevious)->parent.pparent==prelparent?(pparent):(NULL):(NULL);
 					break;
 				}
 
@@ -581,10 +581,10 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 					pcurrchild = pit->parent.pnext?(NULL):pchild;
 					break;
 				case OV_PMH_BEFORE:
-					pcurrchild = (pit->parent.pnext)->child.pchild==prelchild?(pchild):(NULL);
+					pcurrchild = (pit->parent.pnext)?(pit->parent.pnext)->child.pchild==prelchild?(pchild):(NULL):(NULL);
 					break;
 				case OV_PMH_AFTER:
-					pcurrchild = (pit->parent.pnext)->child.pchild==prelchild?(pchild):(NULL);
+					pcurrchild = (pit->parent.pprevious)?(pit->parent.pprevious)->child.pchild==prelchild?(pchild):(NULL):(NULL);
 					break;
 				}
 
@@ -821,13 +821,13 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 		 * additional sanity checks
 		 */
 		switch(passoc->v_assoctype){
-		case OV_AT_ONE_TO_MANY:
-			if((childhint==OV_PMH_BEFORE || childhint==OV_PMH_AFTER) && prelchild==pchild){
+		case OV_AT_MANY_TO_MANY:
+			if((parenthint==OV_PMH_BEFORE || parenthint==OV_PMH_AFTER) && prelparent==pparent){
 				return OV_ERR_BADPLACEMENT;
 			}
 			//fall through
-		case OV_AT_MANY_TO_MANY:
-			if((parenthint==OV_PMH_BEFORE || parenthint==OV_PMH_AFTER) && prelparent==pparent){
+		case OV_AT_ONE_TO_MANY:
+			if((childhint==OV_PMH_BEFORE || childhint==OV_PMH_AFTER) && prelchild==pchild){
 				return OV_ERR_BADPLACEMENT;
 			}
 		}

--- a/core/ov/source/ov_association.c
+++ b/core/ov/source/ov_association.c
@@ -27,9 +27,9 @@
 *	19-Jun-1998 Dirk Meyer <dirk@plt.rwth-aachen.de>: File created.
 *	08-Apr-1999 Dirk Meyer <dirk@plt.rwth-aachen.de>: Major revision.
 *	23-Apr-1999 Dirk Meyer <dirk@plt.rwth-aachen.de>: Optimized (use of macros).
-*	17-Jul-2001 Ansgar Münnemann <ansgar@plt.rwth-aachen.de>: ONE_TO_ONE Link.
-*	10-Dec-2002 Ansgar Münnemann <ansgar@plt.rwth-aachen.de>: Dynamic Assoc Load BugFix (inheritance).
-*	22-Aug-2003 Ansgar Münnemann <ansgar@plt.rwth-aachen.de>: Dynamic Assoc Load BugFix (parentoffset).
+*	17-Jul-2001 Ansgar MÃ¼nnemann <ansgar@plt.rwth-aachen.de>: ONE_TO_ONE Link.
+*	10-Dec-2002 Ansgar MÃ¼nnemann <ansgar@plt.rwth-aachen.de>: Dynamic Assoc Load BugFix (inheritance).
+*	22-Aug-2003 Ansgar MÃ¼nnemann <ansgar@plt.rwth-aachen.de>: Dynamic Assoc Load BugFix (parentoffset).
 */
 
 #define OV_COMPILE_LIBOV
@@ -827,9 +827,6 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 				return OV_ERR_BADPLACEMENT;
 			}
 		}
-		passoc->v_unlinkfnc(pparent, pchild);
-		if(Ov_Fail(result))
-			return result;
 
 		parenthint2 = parenthint;
 		childhint2 = childhint;
@@ -858,6 +855,11 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 			}
 		}
 
+		passoc->v_unlinkfnc(pparent, pchild);
+		if(Ov_Fail(result))
+			return result;
+
+		// call link function again, since unlinking may have invalidated the computed placement
 		return ov_association_link(passoc, pparent, pchild, parenthint2, prelparent2, childhint2, prelchild2);
 	}
 

--- a/core/ov/source/ov_association.c
+++ b/core/ov/source/ov_association.c
@@ -502,13 +502,15 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 		*	in this case simply check, if the child link (anchor) is not already used
 		*/
 		if(Ov_Association_GetParent(passoc, pchild)) {
-			if(Ov_Association_GetParent(passoc, pchild)!=pparent ||
-					childhint == OV_PMH_DEFAULT)
+			if(Ov_Association_GetParent(passoc, pchild)!=pparent)
 				return OV_ERR_ALREADYEXISTS;
 			/*
 			 * check if position is already correct
 			 */
 			switch(childhint){
+			case OV_PMH_DEFAULT:
+				// on placement and already linked
+				return OV_ERR_OK;
 			case OV_PMH_BEGIN:
 				pcurrchild = Ov_Association_GetFirstChild(passoc, pparent);
 				break;
@@ -524,7 +526,8 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 			}
 
 			if(pcurrchild==pchild)
-				return OV_ERR_ALREADYEXISTS;
+				// placement already correct; nothing to do
+				return OV_ERR_OK;
 
 			relink = TRUE;
 		}
@@ -544,7 +547,8 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 		Ov_Association_ForEachChildNM(passoc, pit, pparent, pcurrchild) {
 			if(pcurrchild == pchild) {
 				if(parenthint==OV_PMH_DEFAULT && childhint==OV_PMH_DEFAULT)
-					return OV_ERR_ALREADYEXISTS;
+					// already linked
+					return OV_ERR_OK;
 
 				/*
 				 * check if position is already correct
@@ -585,7 +589,7 @@ OV_DLLFNCEXPORT OV_RESULT ov_association_link(
 				}
 
 				if(pcurrchild==pchild && pcurrparent==pparent)
-					return OV_ERR_ALREADYEXISTS;
+					return OV_ERR_OK;
 
 				relink = TRUE;
 				break;


### PR DESCRIPTION
Changes summary:
- change response to correct existing links to `OV_ERR_OK` (may break applications depending on `KS_ERR_ALREADYEXISTS`)
- do an internal unlink/link, if placement is provided and not jet satisfied
- possible to reorder lists by linking all existing objects with placement